### PR TITLE
Missing CellLocationController added to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@
         <!-- Copy over the Java source files -->
         <source-file src="src/com/esri/cordova/geolocation/AdvancedGeolocation.java" target-dir="src/com/esri/cordova/geolocation" />
 
+        <source-file src="src/com/esri/cordova/geolocation/controllers/CellLocationController.java" target-dir="src/com/esri/cordova/geolocation/controllers" />
         <source-file src="src/com/esri/cordova/geolocation/controllers/GPSController.java" target-dir="src/com/esri/cordova/geolocation/controllers" />
         <source-file src="src/com/esri/cordova/geolocation/controllers/NetworkLocationController.java" target-dir="src/com/esri/cordova/geolocation/controllers" />
 


### PR DESCRIPTION
The `CellLocationController` is missing in the `config.xml` which leads to error during compilation.