### PR TITLE
Don't return an invalid location when the cache is empty

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-advanced-geolocation"
-    version=“0.3.1”>
+    version="0.3.1">
 
     <name>Cordova Advanced Geolocation Plugin - Android</name>
     <description>

--- a/src/com/esri/cordova/geolocation/controllers/GPSController.java
+++ b/src/com/esri/cordova/geolocation/controllers/GPSController.java
@@ -125,14 +125,10 @@ public final class GPSController implements Runnable {
                     // If the provider is disabled or currently unavailable then null is returned
                     // Some devices will return null if the GPS is still warming up and hasn't gotten
                     // a full signal lock yet.
-                    if(location == null) {
-                        // Basically return all zeros as a standard practice
-                        parsedLocation = "{\"provider\":\"gps\",\"latitude\":\"0.0\",\"longitude\":\"0.0\",\"altitude\":\"0.0\",\"accuracy\":\"50.0\",\"bearing\":\"0.0\",\"speed\":\"0.0\",\"timestamp\":\"0\",\"cached\":\"true\"}";
-                    }
-                    else {
+                    if(location != null) {
                         parsedLocation = JSONHelper.locationJSON(LocationManager.GPS_PROVIDER, location, true);
+                        sendCallback(PluginResult.Status.OK, parsedLocation);
                     }
-                    sendCallback(PluginResult.Status.OK, parsedLocation);
                 }
             }
         }


### PR DESCRIPTION
It makes no sense to return something that is completely invalid when nothing is in the cache. Bothering about default position should be part of the application not of this plugin.